### PR TITLE
Export Board to outer class

### DIFF
--- a/ss/cim/board.py
+++ b/ss/cim/board.py
@@ -1,0 +1,74 @@
+import math
+from ss.cim.cell import Cell
+
+
+class Board:
+
+    # Used to give a little extra room to boards to prevent out-of-board errors when particles are at EXACTLY the board
+    #limit
+    EPSILON = 1e-5
+
+    def __init__(self, particles, **kwargs):
+        self.particles = particles
+        self.width = kwargs.get('width')
+        self.height = kwargs.get('height')
+        self.cell_side_length = kwargs.get('cell_side_length')
+        self.is_periodic = kwargs.get('is_periodic', False)
+        self.num_cols = int(math.ceil(self.width / self.cell_side_length))
+        self.num_rows = int(math.ceil(self.height / self.cell_side_length))
+        self.cells = self.create_board()
+        self.populate()
+
+    def to_col_row(self, x, y):
+        row, col = int(y / self.height * self.num_rows), int(x / self.width * self.num_cols)
+        if self.is_periodic:
+            row %= self.num_rows
+            col %= self.num_cols
+        elif not 0 <= row < self.num_rows or not 0 <= col < self.num_cols:
+            raise Exception("(%g, %g) is outside the board, and board is not periodic; max valid coordinates are "
+                            "(%g, %g)" % (x, y, self.width, self.height))
+
+        return col, row
+
+    def get_cell(self, particle):
+        if particle not in self.particles:
+            raise Exception("%s is not part of this board" % particle)
+
+        return self.to_col_row(particle.x, particle.y)
+
+    def create_board(self):
+        """Creates a board of this instance's size, filling each dimension with as many cells as are needed"""
+
+        self.cells = [[]]
+        for y in range(self.num_rows):
+            self.cells.append([])
+            for x in range(int(math.ceil(self.width / self.cell_side_length))):
+                self.cells[y].append(Cell(y, x))
+
+        return self.cells
+
+    def populate(self):
+        """Populates cells with the particles self was initialized with."""
+
+        for particle in self.particles:
+            row, col = self.get_cell(particle)
+            self.cells[row][col].particles.append(particle)
+
+        return self
+
+    def calculate_mbb(self):
+        """Calculates minimum bounding box for this instance's particles"""
+
+        return Board.calculate_mbb(self.particles)
+
+    @staticmethod
+    def calculate_mbb(particles):
+        """Calculates minimum bounding box for a given list of particles. Returns (width, height)"""
+
+        xs, ys = [], []
+        for particle in particles:
+            xs.append(particle.x)
+            ys.append(particle.y)
+
+        # TODO: If min(xs) >> 0, will have a lot of empty space; ídem ys
+        return max(xs) + Board.EPSILON, max(ys) + Board.EPSILON

--- a/ss/cim/board.py
+++ b/ss/cim/board.py
@@ -20,6 +20,8 @@ class Board:
         self.populate()
 
     def to_col_row(self, x, y):
+        """Converts an (X, Y) coordinate to a (row, col) coordinate within this board."""
+
         row, col = int(y / self.height * self.num_rows), int(x / self.width * self.num_cols)
         if self.is_periodic:
             row %= self.num_rows
@@ -51,7 +53,7 @@ class Board:
         """Populates cells with the particles self was initialized with."""
 
         for particle in self.particles:
-            row, col = self.get_cell(particle)
+            col, row = self.get_cell(particle)
             self.cells[row][col].particles.append(particle)
 
         return self

--- a/ss/cim/cell.py
+++ b/ss/cim/cell.py
@@ -24,7 +24,7 @@ class Cell:
 
                 col, row, = self.col + delta_col, self.row + delta_row
                 # Only add cells within the board
-                if 0 <= col < board.num_cols() and 0 <= row < board.num_rows():
+                if 0 <= col < board.num_cols and 0 <= row < board.num_rows:
                     result.append(board.board[row][col])
                 elif board.is_periodic:
                     particles = []

--- a/ss/cim/cell.py
+++ b/ss/cim/cell.py
@@ -25,21 +25,21 @@ class Cell:
                 col, row, = self.col + delta_col, self.row + delta_row
                 # Only add cells within the board
                 if 0 <= col < board.num_cols and 0 <= row < board.num_rows:
-                    result.append(board.board[row][col])
+                    result.append(board.cells[row][col])
                 elif board.is_periodic:
                     particles = []
                     # Create fake cells with fake coordinates for infinite boards
                     delta_x = delta_y = 0
                     if col < 0:
                         delta_x = -board.width
-                    elif col >= board.num_cols():
+                    elif col >= board.num_cols:
                         delta_x = board.width
                     if row < 0:
                         delta_y = -board.height
-                    elif row >= board.num_rows():
+                    elif row >= board.num_rows:
                         delta_y = board.height
 
-                    for original_particle in board.board[row % board.num_rows()][col % board.num_cols()].particles:
+                    for original_particle in board.cells[row % board.num_rows][col % board.num_cols].particles:
                         particles.append(Particle(original_particle.x + delta_x, original_particle.y + delta_y,
                                                   radius=original_particle.radius,
                                                   mass=original_particle.mass,

--- a/ss/cim/cell_index_method.py
+++ b/ss/cim/cell_index_method.py
@@ -1,7 +1,6 @@
 import math
 from ss.util.ddict import Ddict
 from collections import defaultdict
-from ss.cim.cell import Cell
 from ss.cim.board import Board
 
 
@@ -49,46 +48,6 @@ class CellIndexMethod:
         # behavior of returning empty list when accessing a new key (doesn't contemplate invalid keys though, those will
         # also return empty list)
         return result
-
-    def optimal_board_params(self):
-        l = max(self.width, self.height)
-        if self.width == -1 or self.height == -1 or self.m == -1:
-            # Calculate minimum bounding rectangle for particles
-            xs, ys = [], []
-            max_radius = 0
-            for particle in self.particles:
-                xs.append(particle.x)
-                ys.append(particle.y)
-                max_radius = max((max_radius, particle.radius))
-
-            # Compute optimal board parameters
-            width, height = max(xs), max(ys)  # TODO: If min(xs) >> 0 we will have a lot of empty space; ídem ys
-            if self.width == -1:
-                self.width = width
-            if self.height == -1:
-                # If height not provided, assume square board unless the particles would end up outside the board
-                self.height = max(self.width, height)
-
-            # Quick fix to prevent out-of-range bugs when particles are at EXACTLY the board limit
-            epsilon = 1e-5
-            self.width += epsilon
-            self.height += epsilon
-
-            # Recalculate in case width or height were -1 before
-            l = max(self.width, self.height)
-
-            if self.m == -1:
-                # Compute optimal board parameters
-                self.m = math.ceil(l / (self.interaction_radius + 2 * max_radius))
-                if l / self.m <= self.interaction_radius:
-                    # FIXME: This shouldn't happen, revise previous formula
-                    print("WARNING: The calculated M (%i) is over limit, restricting to " % self.m, end="")
-                    self.m = math.floor(l / self.interaction_radius) - 1
-                    print(self.m)
-
-        if l / self.m <= self.interaction_radius:
-            raise Exception("L / M > Rc is not met, can't perform cell index method, aborting. (L = %g, M = %g, "
-                            "Rc = %g)" % (l, self.m, self.interaction_radius))
 
     def get_distances(self, id):
         """List with distances of particle with id to its corresponding neighbors"""

--- a/ss/cim/cell_index_method.py
+++ b/ss/cim/cell_index_method.py
@@ -21,7 +21,7 @@ class CellIndexMethod:
         for row in self.board.cells:
             for cell in row:
                 for me in cell.particles:
-                    for neighbor in cell.getNeighborParticles(self):
+                    for neighbor in cell.getNeighborParticles(self.board):
                         if me == neighbor or neighbor in result[me.id]:
                             continue
 
@@ -35,7 +35,7 @@ class CellIndexMethod:
         for row in self.board.cells:
             for cell in row:
                 for me in cell.particles:
-                    for neighbor in cell.getNeighborParticles(self):
+                    for neighbor in cell.getNeighborParticles(self.board):
                         if me == neighbor or neighbor in result[me.id]:
                             continue
                         distance = me.distance_to(neighbor)


### PR DESCRIPTION
We need to use the Board class even when we don't use the Cell Index Method.  This PR extracts it to a separate class and refactors the Cell Index Method class to use it instead of the inner data it had before.